### PR TITLE
[MAGI-06] - hdfs namenode fails because it tries to recover an unformatted directory

### DIFF
--- a/hdfs/bin/start-namenode.sh
+++ b/hdfs/bin/start-namenode.sh
@@ -4,7 +4,7 @@
 IS_FORMATTED=$(find $HADOOP_NAMENODE_DIR -name VERSION)
 
 if [ -z $IS_FORMATTED ]; then
-    echo "This is the first time this node is starting. Formatting namenode now"
+    echo "Formatting a new name node"
     $HADOOP_HOME/bin/hdfs namenode -format -force
 else
     echo "Recovering namenode"


### PR DESCRIPTION
Something is weird with the build cache or something, either that or a local push screwed something up.

Resolves https://github.com/magi-platform/magi/issues/13